### PR TITLE
high-speed analysis with multiband support

### DIFF
--- a/ProfAmpli.pro
+++ b/ProfAmpli.pro
@@ -19,7 +19,9 @@ HEADERS = \
     sources/analyzerdefs.h \
     sources/messages.h \
     sources/utility/nextpow2.h \
-    sources/utility/ring_buffer.h
+    sources/utility/ring_buffer.h \
+    sources/utility/counting_bitset.h \
+    sources/utility/counting_bitset.tcc
 
 FORMS = \
     forms/mainwindow.ui

--- a/forms/mainwindow.ui
+++ b/forms/mainwindow.ui
@@ -229,6 +229,76 @@ border-radius: 10px;</string>
         </widget>
        </item>
        <item>
+        <widget class="QFrame" name="frame_9">
+         <property name="frameShape">
+          <enum>QFrame::StyledPanel</enum>
+         </property>
+         <property name="frameShadow">
+          <enum>QFrame::Raised</enum>
+         </property>
+         <layout class="QVBoxLayout" name="verticalLayout_9">
+          <property name="leftMargin">
+           <number>4</number>
+          </property>
+          <property name="topMargin">
+           <number>4</number>
+          </property>
+          <property name="rightMargin">
+           <number>4</number>
+          </property>
+          <property name="bottomMargin">
+           <number>4</number>
+          </property>
+          <item>
+           <widget class="QLabel" name="label_7">
+            <property name="text">
+             <string>Parallel</string>
+            </property>
+           </widget>
+          </item>
+          <item>
+           <spacer name="verticalSpacer_7">
+            <property name="orientation">
+             <enum>Qt::Vertical</enum>
+            </property>
+            <property name="sizeHint" stdset="0">
+             <size>
+              <width>20</width>
+              <height>5</height>
+             </size>
+            </property>
+           </spacer>
+          </item>
+          <item>
+           <widget class="QSpinBox" name="sp_parallel">
+            <property name="suffix">
+             <string>×</string>
+            </property>
+            <property name="minimum">
+             <number>1</number>
+            </property>
+            <property name="maximum">
+             <number>16</number>
+            </property>
+           </widget>
+          </item>
+          <item>
+           <spacer name="verticalSpacer_8">
+            <property name="orientation">
+             <enum>Qt::Vertical</enum>
+            </property>
+            <property name="sizeHint" stdset="0">
+             <size>
+              <width>20</width>
+              <height>0</height>
+             </size>
+            </property>
+           </spacer>
+          </item>
+         </layout>
+        </widget>
+       </item>
+       <item>
         <widget class="QFrame" name="frame_7">
          <property name="frameShape">
           <enum>QFrame::StyledPanel</enum>
@@ -542,7 +612,7 @@ border-radius: 10px;</string>
      <x>0</x>
      <y>0</y>
      <width>830</width>
-     <height>25</height>
+     <height>17</height>
     </rect>
    </property>
   </widget>

--- a/forms/mainwindow.ui
+++ b/forms/mainwindow.ui
@@ -6,8 +6,8 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>830</width>
-    <height>508</height>
+    <width>800</width>
+    <height>600</height>
    </rect>
   </property>
   <property name="windowTitle">
@@ -181,19 +181,6 @@
            </widget>
           </item>
           <item>
-           <spacer name="verticalSpacer_3">
-            <property name="orientation">
-             <enum>Qt::Vertical</enum>
-            </property>
-            <property name="sizeHint" stdset="0">
-             <size>
-              <width>20</width>
-              <height>0</height>
-             </size>
-            </property>
-           </spacer>
-          </item>
-          <item>
            <widget class="QLabel" name="lbl_frequency">
             <property name="styleSheet">
              <string notr="true">color: #00ff00;
@@ -206,6 +193,45 @@ border-radius: 10px;</string>
             </property>
             <property name="text">
              <string>0 Hz</string>
+            </property>
+            <property name="alignment">
+             <set>Qt::AlignCenter</set>
+            </property>
+           </widget>
+          </item>
+          <item>
+           <spacer name="verticalSpacer_9">
+            <property name="orientation">
+             <enum>Qt::Vertical</enum>
+            </property>
+            <property name="sizeHint" stdset="0">
+             <size>
+              <width>20</width>
+              <height>0</height>
+             </size>
+            </property>
+           </spacer>
+          </item>
+          <item>
+           <widget class="QLabel" name="label_8">
+            <property name="text">
+             <string>Sweep</string>
+            </property>
+           </widget>
+          </item>
+          <item>
+           <widget class="QLabel" name="lbl_sweep">
+            <property name="styleSheet">
+             <string notr="true">color: #00ff00;
+background-color: black;
+font-weight: bold;
+border-width: 2px;
+border-style: solid;
+border-color: #dddddd;
+border-radius: 10px;</string>
+            </property>
+            <property name="text">
+             <string>Lo</string>
             </property>
             <property name="alignment">
              <set>Qt::AlignCenter</set>
@@ -611,7 +637,7 @@ border-radius: 10px;</string>
     <rect>
      <x>0</x>
      <y>0</y>
-     <width>830</width>
+     <width>800</width>
      <height>17</height>
     </rect>
    </property>

--- a/sources/analyzerdefs.h
+++ b/sources/analyzerdefs.h
@@ -21,6 +21,10 @@ enum {
     sweep_length = 128,
 };
 
+enum {
+    max_bins_at_once = 32,
+};
+
 enum Signal_Pseudo_Level {
     Signal_Lo,
     Signal_Hi,
@@ -39,6 +43,11 @@ inline constexpr double spl_amplitude(int spl)
 inline double global_amplitude(int spl)
 {
     return spl_amplitude(spl) * global_gain;
+}
+
+inline unsigned nth_bin_position(unsigned sweep_index, unsigned nth_bin, unsigned count_at_once)
+{
+    return (sweep_index + nth_bin * Analysis::sweep_length / count_at_once) % Analysis::sweep_length;
 }
 
 }  // namespace Analysis

--- a/sources/application.cc
+++ b/sources/application.cc
@@ -44,6 +44,7 @@ struct Application::Impl {
     bool hi_enable_ = true;
     int next_spl_phase(int spl) const;
     bool enabled_spl(int spl) const;
+    void set_sweep_phase(int spl);
 };
 
 Application::Application(int &argc, char *argv[])
@@ -108,7 +109,7 @@ void Application::setSweepEnabled(bool lo, bool hi)
     if (disabled) {
         int next = P->next_spl_phase(P->sweep_spl_);
         if (next != -1) {
-            P->sweep_spl_ = next;
+            P->set_sweep_phase(next);
             P->tm_nextsweep_->start(0);
         }
     }
@@ -222,7 +223,7 @@ void Application::realtimeUpdateTick()
                 spl = P->next_spl_phase(P->sweep_spl_);
             }
             P->sweep_index_ = index;
-            P->sweep_spl_ = spl;
+            P->set_sweep_phase(spl);
 
             unsigned progress = P->sweep_progress_;
             progress += done_bins;
@@ -294,4 +295,12 @@ bool Application::Impl::enabled_spl(int spl) const
     case Analysis::Signal_Hi:
         return hi_enable_;
     }
+}
+
+void Application::Impl::set_sweep_phase(int spl)
+{
+    if (sweep_spl_ == spl)
+        return;
+    sweep_spl_ = spl;
+    emit theApplication->sweepPhaseChanged(spl);
 }

--- a/sources/application.h
+++ b/sources/application.h
@@ -22,6 +22,9 @@ public:
     void setSweepEnabled(bool lo, bool hi);
     void setFreqsAtOnce(unsigned count);
 
+signals:
+    void sweepPhaseChanged(int spl);
+
 public slots:
     void setSweepActive(bool active);
     void saveProfile();

--- a/sources/application.h
+++ b/sources/application.h
@@ -20,6 +20,7 @@ public:
     void setMainWindow(MainWindow &win);
 
     void setSweepEnabled(bool lo, bool hi);
+    void setFreqsAtOnce(unsigned count);
 
 public slots:
     void setSweepActive(bool active);

--- a/sources/audioprocessor.cc
+++ b/sources/audioprocessor.cc
@@ -296,7 +296,7 @@ void Audio_Processor::Impl::compute_response(cfloat *response)
         unsigned bin = std::lround(n * f);
         cfloat h_out = cplx[bin] * 4.0f / (float)n;
         cfloat h_in = std::polar(
-            (float)Analysis::global_amplitude(gen_spl_),
+            (float)Analysis::global_amplitude(gen_spl_) * gen_gain_compensate_,
             2 * (float)M_PI * gen_starting_phase_[a]);
         response[a] = h_out / h_in;
     }

--- a/sources/mainwindow.cc
+++ b/sources/mainwindow.cc
@@ -119,6 +119,18 @@ MainWindow::MainWindow(QWidget *parent)
     connect(
         P->ui.sp_parallel, QOverload<int>::of(&QSpinBox::valueChanged),
         this, [](int num) { theApplication->setFreqsAtOnce(num); });
+
+    connect(
+        theApplication, &Application::sweepPhaseChanged,
+        this, [this](int spl) {
+                  const char *text;
+                  switch (spl) {
+                  case Analysis::Signal_Lo: text = "Lo"; break;
+                  case Analysis::Signal_Hi: text = "Hi"; break;
+                  default: text = "None"; break;
+                  }
+                  P->ui.lbl_sweep->setText(text);
+              });
 }
 
 MainWindow::~MainWindow()

--- a/sources/mainwindow.cc
+++ b/sources/mainwindow.cc
@@ -12,6 +12,7 @@
 #include <qwt_plot_marker.h>
 #include <qwt_plot_grid.h>
 #include <qwt_plot_legenditem.h>
+#include <qwt_symbol.h>
 #include <cmath>
 
 struct MainWindow::Impl {
@@ -40,19 +41,26 @@ MainWindow::MainWindow(QWidget *parent)
         grid->attach(plt);
     }
 
+    QColor color_lo(Qt::green);
+    QColor color_hi(Qt::red);
+
     QwtPlotCurve *curve_lo_mag = P->curve_lo_mag_ = new QwtPlotCurve(tr("Lo Signal Gain"));
     curve_lo_mag->attach(P->ui.pltAmplitude);
-    curve_lo_mag->setPen(Qt::green, 0.0, Qt::SolidLine);
+    curve_lo_mag->setPen(color_lo, 0.0, Qt::SolidLine);
     QwtPlotCurve *curve_lo_phase = P->curve_lo_phase_ = new QwtPlotCurve(tr("Lo Signal Phase"));
+    curve_lo_phase->setStyle(QwtPlotCurve::NoCurve);
+    QwtSymbol *sym_lo_phase = new QwtSymbol(QwtSymbol::Ellipse, QBrush(Qt::transparent), QPen(color_lo), QSize(6, 6));
+    curve_lo_phase->setSymbol(sym_lo_phase);
     curve_lo_phase->attach(P->ui.pltPhase);
-    curve_lo_phase->setPen(Qt::green, 0.0, Qt::SolidLine);
 
     QwtPlotCurve *curve_hi_mag = P->curve_hi_mag_ = new QwtPlotCurve(tr("Hi Signal Gain"));
     curve_hi_mag->attach(P->ui.pltAmplitude);
-    curve_hi_mag->setPen(Qt::red, 0.0, Qt::SolidLine);
+    curve_hi_mag->setPen(color_hi, 0.0, Qt::SolidLine);
     QwtPlotCurve *curve_hi_phase = P->curve_hi_phase_ = new QwtPlotCurve(tr("Hi Signal Phase"));
+    curve_hi_phase->setStyle(QwtPlotCurve::NoCurve);
+    QwtSymbol *sym_hi_phase = new QwtSymbol(QwtSymbol::Triangle, QBrush(Qt::transparent), QPen(color_hi), QSize(6, 6));
+    curve_hi_phase->setSymbol(sym_hi_phase);
     curve_hi_phase->attach(P->ui.pltPhase);
-    curve_hi_phase->setPen(Qt::red, 0.0, Qt::SolidLine);
 
     QwtPlotMarker *marker_mag = P->marker_mag_ = new QwtPlotMarker;
     marker_mag->attach(P->ui.pltAmplitude);

--- a/sources/mainwindow.cc
+++ b/sources/mainwindow.cc
@@ -114,6 +114,11 @@ MainWindow::MainWindow(QWidget *parent)
             P->curve_hi_mag_->setVisible(checked);
             P->curve_hi_phase_->setVisible(checked);
         });
+
+    P->ui.sp_parallel->setRange(1, Analysis::max_bins_at_once);
+    connect(
+        P->ui.sp_parallel, QOverload<int>::of(&QSpinBox::valueChanged),
+        this, [](int num) { theApplication->setFreqsAtOnce(num); });
 }
 
 MainWindow::~MainWindow()

--- a/sources/messages.h
+++ b/sources/messages.h
@@ -4,6 +4,7 @@
 //          http://www.boost.org/LICENSE_1_0.txt)
 
 #pragma once
+#include "analyzerdefs.h"
 #include <complex>
 #include <cstddef>
 #include <cstdint>
@@ -38,17 +39,19 @@ namespace Messages {
         struct t : public Basic_Message_T<Message_Tag::t>
 
     DEFMESSAGE(RequestAnalyzeFrequency) {
-        float frequency;
         int spl;
+        unsigned num_bins;
+        float frequency[Analysis::max_bins_at_once];
     };
 
     DEFMESSAGE(RequestStop) {
     };
 
     DEFMESSAGE(NotifyFrequencyAnalysis) {
-        float frequency;
         int spl;
-        std::complex<float> response;
+        unsigned num_bins;
+        float frequency[Analysis::max_bins_at_once];
+        std::complex<float> response[Analysis::max_bins_at_once];
     };
 
     #undef DEFMESSAGE

--- a/sources/utility/counting_bitset.h
+++ b/sources/utility/counting_bitset.h
@@ -1,0 +1,44 @@
+//          Copyright Jean Pierre Cimalando 2018.
+// Distributed under the Boost Software License, Version 1.0.
+//    (See accompanying file LICENSE or copy at
+//          http://www.boost.org/LICENSE_1_0.txt)
+
+#pragma once
+#include <bitset>
+
+template <size_t N>
+struct counting_bitset {
+    constexpr counting_bitset();
+
+    counting_bitset(const counting_bitset &) = default;
+    counting_bitset &operator=(const counting_bitset &) = default;
+
+    bool operator==(const counting_bitset &o) const;
+    bool operator!=(const counting_bitset &o) const;
+
+    bool test(size_t pos) const;
+
+    bool all() const;
+    bool any() const;
+    bool none() const;
+
+    size_t count() const;
+
+    counting_bitset &set();
+    counting_bitset &set(size_t pos, bool value = true);
+
+    counting_bitset &reset();
+    counting_bitset &reset(size_t pos);
+
+    counting_bitset &flip();
+    counting_bitset &flip(size_t pos);
+
+    template <class CharT = char, class Traits = std::char_traits<CharT>, class Allocator = std::allocator<CharT>>
+    std::basic_string<CharT, Traits, Allocator> to_string(CharT zero = CharT('0'), CharT one = CharT('1')) const;
+
+private:
+    size_t count_ = 0;
+    std::bitset<N> bits_;
+};
+
+#include "counting_bitset.tcc"

--- a/sources/utility/counting_bitset.tcc
+++ b/sources/utility/counting_bitset.tcc
@@ -1,0 +1,110 @@
+//          Copyright Jean Pierre Cimalando 2018.
+// Distributed under the Boost Software License, Version 1.0.
+//    (See accompanying file LICENSE or copy at
+//          http://www.boost.org/LICENSE_1_0.txt)
+
+#include "counting_bitset.h"
+
+template <size_t N>
+constexpr counting_bitset<N>::counting_bitset()
+{
+}
+
+template <size_t N>
+bool counting_bitset<N>::operator==(const counting_bitset &o) const
+{
+    return count_ == o.count_ && bits_ == o.bits_;
+}
+
+template <size_t N>
+bool counting_bitset<N>::operator!=(const counting_bitset &o) const
+{
+    return !operator==(o);
+}
+
+template <size_t N>
+bool counting_bitset<N>::test(size_t pos) const
+{
+    return bits_.test(pos);
+}
+
+template <size_t N>
+bool counting_bitset<N>::all() const
+{
+    return count_ == N;
+}
+
+template <size_t N>
+bool counting_bitset<N>::any() const
+{
+    return count_ > 0;
+}
+
+template <size_t N>
+bool counting_bitset<N>::none() const
+{
+    return count_ == 0;
+}
+
+template <size_t N>
+size_t counting_bitset<N>::count() const
+{
+    return count_;
+}
+
+template <size_t N>
+auto counting_bitset<N>::set() -> counting_bitset &
+{
+    count_ = N;
+    bits_.set();
+    return *this;
+}
+
+template <size_t N>
+auto counting_bitset<N>::set(size_t pos, bool value) -> counting_bitset &
+{
+    if (bits_.test(pos) != value) {
+        count_ = (ptrdiff_t)count_ + (value ? +1 : -1);
+        bits_.set(pos, value);
+    }
+    return *this;
+}
+
+template <size_t N>
+auto counting_bitset<N>::reset() -> counting_bitset &
+{
+    count_ = 0;
+    bits_.reset();
+    return *this;
+}
+
+template <size_t N>
+auto counting_bitset<N>::reset(size_t pos) -> counting_bitset &
+{
+    set(pos, false);
+    return *this;
+}
+
+template <size_t N>
+auto counting_bitset<N>::flip() -> counting_bitset &
+{
+    count_ = N - count_;
+    bits_.flip();
+    return *this;
+}
+
+template <size_t N>
+auto counting_bitset<N>::flip(size_t pos) -> counting_bitset &
+{
+    bool value = !bits_.test(pos);
+    count_ = (ptrdiff_t)count_ + (value ? +1 : -1);
+    bits_.set(pos, value);
+    return *this;
+}
+
+template <size_t N>
+template<class CharT, class Traits, class Allocator>
+std::basic_string<CharT, Traits, Allocator> counting_bitset<N>::to_string(CharT zero, CharT one) const
+{
+    return bits_.template to_string<CharT, Traits, Allocator>();
+}


### PR DESCRIPTION
Allows frequency response analysis to process multiple sinewaves per sweep.
It is a speed up by 2x to 32x.
It is set to spread out optimally over the spectrum, to prevent artifacts as much as possible.

notify @jujudusud